### PR TITLE
Check the response status code when fetching Sources.gz file

### DIFF
--- a/cmadison/cmadison.py
+++ b/cmadison/cmadison.py
@@ -13,6 +13,7 @@
 from __future__ import print_function
 
 from lxml import etree
+from requests.exceptions import HTTPError
 import argparse
 import gzip
 import logging as log
@@ -23,13 +24,6 @@ import requests_cache
 import shutil
 import subprocess
 import tempfile
-
-try:
-    # python2
-    from urllib2 import HTTPError
-except ImportError:
-    # python3
-    from urllib.error import HTTPError
 
 
 # Defines teh default ubuntu cloud-archive repository URL.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lxml
 requests
 requests-cache
+requestsexceptions


### PR DESCRIPTION
Fixes #5

The fix prevent cmadison to crash at occurence of a 404 error
by detecting 404 error specifically.

Traceback (most recent call last):
  File "./cmadison.py", line 366, in <module>
    main()
  File "./cmadison.py", line 355, in main
    do_cloudarchive_search(args.package, print_prefix, args.eol)
  File "./cmadison.py", line 268, in do_cloudarchive_search
    for src in Sources(dist, os_release).get_sources():
  File "./cmadison.py", line 128, in __init__
    self.ready = self.download()
  File "./cmadison.py", line 142, in download
    resp.raise_for_status()
  File "/usr/lib/python2.7/dist-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://ubuntu-cloud.archive.canonical.com/ubuntu/dists/precise-updates/stein/main/source/Sources.gz

Signed-off-by: Eric Desrochers <eric.desrochers@canonical.com>