### PR TITLE
Delete cache file rather than CACHE_DIR

### DIFF
--- a/cmadison/cmadison.py
+++ b/cmadison/cmadison.py
@@ -22,7 +22,6 @@ import os.path
 import requests
 import requests_cache
 import six
-import shutil
 import tempfile
 
 
@@ -350,7 +349,9 @@ def do_cloudarchive_search(package, print_source=False, show_eol=False):
 
 def clear_cache():
     """Removes the cache data"""
-    shutil.rmtree(CACHE_DIR)
+    cache_file = '{cache_dir}/cmadison.sqlite'.format(cache_dir=CACHE_DIR)
+    if os.path.exists(cache_file):
+        os.remove(cache_file)
 
 
 def setup_cache(cache_period):


### PR DESCRIPTION
The CACHE_DIR for snaps points to the SNAP_USER_DIR which cannot
be removed. This causes the --clear-cache flag to fail because the
code tries to simply remove the CACHE_DIR directory.

This change makes it where the sqlite database containing the
cache data is simply removed rather than the CACHE_DIR.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>